### PR TITLE
Add connector for AWS Keyspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ And add a new cassandra connection:
             'keyspace' => env('DB_DATABASE', 'cassandra_db'),
         	'username' => env('DB_USERNAME', ''),
         	'password' => env('DB_PASSWORD', ''),
+            'password' => env('DB_CERTFILE', ''),
      ],
 
 ### **Auth**

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ And add a new cassandra connection:
             'password' => env('DB_CERTFILE', ''),
      ],
 
+For AWS Keyspaces, the DB_CERTFILE can be generated via the following:
+
+```
+curl https://certs.secureserver.net/repository/sf-class2-root.crt -O
+```
+
+Once you have the file sf-class2-root.crt, you can store this in a secure directory and reference it via the DB_CERTFILE environment variable.
+
 ### **Auth**
 
 You can use Laravel's native Auth functionality for cassandra, make sure your config/auth.php looks like 


### PR DESCRIPTION
## Description

When connecting to AWS Keyspaces as our Cassandra instance, the connection relies via secure TLS/SSL connections and needs to be supplied an SSL certificate. 

Thus this update adds an AWS-only connect method and an additional environment variable reference to the supplied certificate file. 

The certificate file is generated via `curl https://certs.secureserver.net/repository/sf-class2-root.crt -O`

(See https://docs.aws.amazon.com/keyspaces/latest/devguide/programmatic.cqlsh.html for reference).